### PR TITLE
Allow ngrok inspector

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,7 @@
-export WEBHOOK_URI=https://some.example.com/shop/example
-export API_KEY=""
-export API_SECRET=""
-export ADMIN_API_ENDPOINT=""
 
 source_env_if_exists .envrc.private
+export WEBHOOK_URI=https://$HOST/shopify/webhook/shopify_app
+export AUTH_REDIRECT_URI=https://$HOST/shop/authorized/shopify_app
+export ADMIN_API_ENDPOINT=https://$HOST/api/admin
+export STOREFRONT_API_ENDPOINT=https://$HOST/api/store_front
 # vi:syntax=bash

--- a/.envrc.private.example
+++ b/.envrc.private.example
@@ -1,6 +1,7 @@
-export WEBHOOK_URI=https://some.example.com/shop/example
 export API_KEY=""
 export API_SECRET=""
-export ADMIN_API_ENDPOINT=""
+export NGROK_AUTH=""
+export NGROK_SUBDOMAIN=""
+export HOST=$NGROK_SUBDOMAIN.ngrok.io
 
 # vi:syntax=bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,5 @@ services:
       - "NGROK_AUTH=${NGROK_AUTH}"
       - "NGROK_PORT=host.docker.internal:4000"
       - "NGROK_SUBDOMAIN=${NGROK_SUBDOMAIN}"
+    ports:
+      - "4040:4040"


### PR DESCRIPTION

- Allow ngrok inspector by opening 4040 in the ngrok service. 
- Added NGROK_AUTH and NGROK_SUBDOMAIN to .envrc.private.example to make running ngrok more obvious.