### PR TITLE
Add barebones shop_admin LiveView

### DIFF
--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -1,0 +1,49 @@
+# ShopifyApp
+
+## Prerequisite
+
+- [asdf](https://asdf-vm.com/)
+- Docker / Docker Compose
+- Access to a Shopify Partners Dashboard
+- An ngrok account
+
+## Development
+
+- install with asdf (install the plugins first if you do not have them, e.g. `asdf plugin-add elixir`)
+    - `asdf install`
+- Setup environment variables
+    - ensure direnv is working `https://direnv.net/docs/hook.html`
+    - Create .envrc.private `cp .envrc.private.example .envrc.private` and update values.
+- Start database and ngrok
+    - `docker-compose up`
+- Create Shopify App and Shop
+- Fetch Elixir Deps, create database
+    - `mix deps.get`
+    - `mix ecto.setup`
+
+### Running
+
+- Run the app locally with `mix phx.server` or `iex -S mix phx.server` for a REPL.
+
+### Shop Install
+
+- Install the the app to a shopify shop with https://mysubdomain.ngrok.io/shop/install?shop=myshop.myshopify.com&app=shopify_app (replacing `mysubdomain` and `app=shopify_app`)
+
+# Organization
+
+## Shop Admin
+
+The Shop Admin is a place inside of Shopify that the merchant can access and configure the app.
+
+The ShopAdmin is serverd up as a LiveView in an iframe. It uses [AppBridge](https://shopify.dev/docs/api/app-bridge-library/reference) to communicate with the parent. It uses [Polaris](https://polaris.shopify.com) as the design language.
+
+### Implementation Notes
+
+The ShopAdmin lives on the `/shop_admin/:app` route and is part of the `:shop_admin` live_session. Most of the relevant files can be found in `lib/shopify_app_web/live/shop_admin/`. The ShopAdmin has its own root and app layouts, including its own JS which adds a few extra considerations for interacting with AppBridge.
+
+#### AppBridge Considerations
+
+- We hook `phx:page-loading-start` events into [AppBridge loading](https://shopify.dev/docs/api/app-bridge-library/reference/loading)
+- We can interact with the AppBride [Title Bar with `<ui-title-bar/>` componenet](https://shopify.dev/docs/api/app-bridge-library/reference/navigation-menu). We can add action buttons to the title bar. However `<ui-title-bar/>` requires that attributes of any of its children do not take the form of `phx-` such as `phx-click`, **instead we must use the `data-phx-` prefix** ( `bindingPrefix: "data-phx-"`). This affects all LiveViews using `use ShopifyAppWeb, :shop_admin_live_view`, which should be all and only ShopAdmin LiveViews. This unfortunately means that we cannot share CoreComponents between ShopAdmin and non ShopAdmin LiveViews.
+- We can interact with the AppBridge [Navigation Menu with `ui-nav-menu`](https://shopify.dev/docs/api/app-bridge-library/reference/navigation-menu). This lives in `lib/shopify_app_web/live/shop_admin/layouts/app.html.heex`. AppBridge __should__ detect any navigation within the iframe and reflect that in the Navigation Menu, we re-trigger `history.replaceState` when we navigate between liveviews to give it an extra nudge. In general, AppBridge Navigation Menu updates does not work unless you enter into ShopAdmin from the root path (ie. `/shop_admin/:app` not `/shop_admin/:app/settigns`)
+- Instead of traditional `<.flash />` for flash messages, we use the [LiveBridge Toast](https://shopify.dev/docs/api/app-bridge-library/reference/toast) with `<.toast />` (using `ShopifyToastHook`). The toast is still activated with `put_flash/3`.

--- a/assets/js/hooks/index.js
+++ b/assets/js/hooks/index.js
@@ -1,0 +1,15 @@
+/*
+Handles the integration between flash to a Shopify AppBridge Toast
+
+See ShopAdminComponents.toast
+*/
+export const ShopifyToastHook = {
+  mounted() {
+    shopify.toast.show(this.el.dataset.message, {
+      onDismiss: () => {
+        this.pushEvent("lv:clear-flash", {value: {key: this.el.dataset.kind}})
+      },
+      isError: this.el.dataset.kind == 'error'
+    });
+  }
+}

--- a/assets/js/shop_admin.js
+++ b/assets/js/shop_admin.js
@@ -5,9 +5,11 @@ import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
+import {ShopifyToastHook} from "./hooks"
 
+let Hooks = { ShopifyToastHook }
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}})
 
 // Show progress bar on live navigation and form submits
 window.addEventListener("phx:page-loading-start", _info => shopify.loading(true))

--- a/assets/js/shop_admin.js
+++ b/assets/js/shop_admin.js
@@ -13,6 +13,21 @@ let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToke
 window.addEventListener("phx:page-loading-start", _info => shopify.loading(true))
 window.addEventListener("phx:page-loading-stop", _info => shopify.loading(false))
 
+window.addEventListener("phx:page-loading-stop", info => {
+  /*
+    When navigating, AppBridge detects changes within a LiveView,
+    however, it does not detect between LiveView navigation, even when it is
+    correctly patching within a live_session. This re-emits a navigation event
+    that AppBridge will detect.
+  */
+  destination = new URL(info.detail.to).pathname
+  if (info.detail.kind == "initial" && destination != window.location.pathname) {
+    history.pushState(null, '', destination);
+  } else {
+    history.replaceState(null, '', destination);
+  }
+})
+
 // connect if there are any LiveViews on the page
 liveSocket.connect()
 

--- a/assets/js/shop_admin.js
+++ b/assets/js/shop_admin.js
@@ -9,7 +9,7 @@ import {ShopifyToastHook} from "./hooks"
 
 let Hooks = { ShopifyToastHook }
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}, bindingPrefix: "data-phx-"})
+let liveSocket = new LiveSocket("/shop_admin_live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}, bindingPrefix: "data-phx-"})
 
 // Show progress bar on live navigation and form submits
 window.addEventListener("phx:page-loading-start", _info => shopify.loading(true))
@@ -22,7 +22,7 @@ window.addEventListener("phx:page-loading-stop", info => {
     correctly patching within a live_session. This re-emits a navigation event
     that AppBridge will detect.
   */
-  destination = new URL(info.detail.to).pathname
+  const destination = new URL(info.detail.to).pathname
   if (info.detail.kind == "initial" && destination != window.location.pathname) {
     history.pushState(null, '', destination);
   } else {

--- a/assets/js/shop_admin.js
+++ b/assets/js/shop_admin.js
@@ -9,7 +9,7 @@ import {ShopifyToastHook} from "./hooks"
 
 let Hooks = { ShopifyToastHook }
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}, bindingPrefix: "data-phx-"})
 
 // Show progress bar on live navigation and form submits
 window.addEventListener("phx:page-loading-start", _info => shopify.loading(true))

--- a/assets/js/shop_admin.js
+++ b/assets/js/shop_admin.js
@@ -1,0 +1,23 @@
+// JS specific to LiveView in ShopAdmin
+
+// Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
+import "phoenix_html"
+// Establish Phoenix Socket and LiveView configuration.
+import {Socket} from "phoenix"
+import {LiveSocket} from "phoenix_live_view"
+
+let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
+let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+
+// Show progress bar on live navigation and form submits
+window.addEventListener("phx:page-loading-start", _info => shopify.loading(true))
+window.addEventListener("phx:page-loading-stop", _info => shopify.loading(false))
+
+// connect if there are any LiveViews on the page
+liveSocket.connect()
+
+// expose liveSocket on window for web console debug logs and latency simulation:
+// >> liveSocket.enableDebug()
+// >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
+// >> liveSocket.disableLatencySim()
+window.liveSocket = liveSocket

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,7 +34,7 @@ config :esbuild,
   version: "0.14.41",
   default: [
     args:
-      ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
+      ~w(js/app.js js/shop_admin.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
     cd: Path.expand("../assets", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]

--- a/lib/shopify_app_web.ex
+++ b/lib/shopify_app_web.ex
@@ -66,6 +66,17 @@ defmodule ShopifyAppWeb do
     end
   end
 
+  def shop_admin_live_view do
+    quote do
+      use Phoenix.LiveView,
+        layout: {ShopifyAppWeb.Layouts, :app}
+
+      import ShopifyAppWeb.ShopAdminComponents
+
+      unquote(html_helpers())
+    end
+  end
+
   def html do
     quote do
       use Phoenix.Component

--- a/lib/shopify_app_web.ex
+++ b/lib/shopify_app_web.ex
@@ -69,11 +69,19 @@ defmodule ShopifyAppWeb do
   def shop_admin_live_view do
     quote do
       use Phoenix.LiveView,
-        layout: {ShopifyAppWeb.Layouts, :app}
+        layout: {ShopifyAppWeb.ShopAdminLive.Layouts, :app}
 
       import ShopifyAppWeb.ShopAdminComponents
 
-      unquote(html_helpers())
+      # HTML escaping functionality
+      import Phoenix.HTML
+      import ShopifyAppWeb.Gettext
+
+      # Shortcut for generating JS commands
+      alias Phoenix.LiveView.JS
+
+      # Routes generation with the ~p sigil
+      unquote(verified_routes())
     end
   end
 

--- a/lib/shopify_app_web/components/core_components.ex
+++ b/lib/shopify_app_web/components/core_components.ex
@@ -220,6 +220,7 @@ defmodule ShopifyAppWeb.CoreComponents do
   """
   attr :type, :string, default: nil
   attr :class, :string, default: nil
+  attr :variant, :string, default: nil
   attr :rest, :global, include: ~w(disabled form name value)
 
   slot :inner_block, required: true
@@ -228,6 +229,7 @@ defmodule ShopifyAppWeb.CoreComponents do
     ~H"""
     <button
       type={@type}
+      variant={@variant}
       class={[
         "phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
         "text-sm font-semibold leading-6 text-white active:text-white/80",

--- a/lib/shopify_app_web/components/shop_admin_components.ex
+++ b/lib/shopify_app_web/components/shop_admin_components.ex
@@ -12,9 +12,15 @@ defmodule ShopifyAppWeb.ShopAdminComponents do
     ~H"""
     <div>
       <ul>
-        <li><.link patch={~p"/shop_admin/shopify_app/"}>Home</.link></li>
-        <li><.link patch={~p"/shop_admin/shopify_app/settings"}>Settings</.link></li>
-        <li><.link patch={~p"/shop_admin/shopify_app/more"}>More Settings</.link></li>
+        <%!--
+          # if we want to navigate back to react land, we need to remount with the HMAC
+          See https://shopify.dev/docs/api/app-bridge-library/reference/navigation
+          <li><a href="shopify:admin/apps/my-shopify-app-mount/shop_admin" target="_top">Home</a></li>
+        --%>
+        <li><.link patch={~p"/live_shop_admin/"}>Home</.link></li>
+        <li><.link patch={~p"/live_shop_admin/show"}>Show</.link></li>
+        <li><.link patch={~p"/live_shop_admin/settings"}>Settings</.link></li>
+        <li><.link patch={~p"/live_shop_admin/more"}>More Settings</.link></li>
       </ul>
     </div>
     """

--- a/lib/shopify_app_web/components/shop_admin_components.ex
+++ b/lib/shopify_app_web/components/shop_admin_components.ex
@@ -42,11 +42,43 @@ defmodule ShopifyAppWeb.ShopAdminComponents do
       id={@id}
       data-message={msg}
       data-kind={@kind}
-      phx-hook="ShopifyToastHook"
+      data-phx-hook="ShopifyToastHook"
       hidden
     >
       <%= msg %>
     </div>
+    """
+  end
+
+  @doc """
+  Renders a button.
+
+  ## Examples
+
+      <.button>Send!</.button>
+      <.button data-phx-click="go" class="ml-2">Send!</.button>
+  """
+  attr :type, :string, default: nil
+  attr :class, :string, default: nil
+  attr :variant, :string, default: nil
+  attr :rest, :global, include: ~w(disabled form name value)
+
+  slot :inner_block, required: true
+
+  def button(assigns) do
+    ~H"""
+    <button
+      type={@type}
+      variant={@variant}
+      class={[
+        "phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
+        "text-sm font-semibold leading-6 text-white active:text-white/80",
+        @class
+      ]}
+      {@rest}
+    >
+      <%= render_slot(@inner_block) %>
+    </button>
     """
   end
 end

--- a/lib/shopify_app_web/components/shop_admin_components.ex
+++ b/lib/shopify_app_web/components/shop_admin_components.ex
@@ -19,4 +19,34 @@ defmodule ShopifyAppWeb.ShopAdminComponents do
     </div>
     """
   end
+
+  @doc """
+  Renders Shopify toast notices.
+
+  Uses ShopifyToastHook to integrate with AppBridge
+    https://shopify.dev/docs/api/app-bridge-library/reference/toast#example-toast-with-dismiss-callback
+
+  ## Examples
+
+      <.toast kind={:info} flash={@flash} />
+      <.toast kind={:error} flash={@flash} />
+  """
+  attr :id, :string, default: "toast", doc: "the optional id of toast container"
+  attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
+  attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
+
+  def toast(assigns) do
+    ~H"""
+    <div
+      :if={msg = Phoenix.Flash.get(@flash, @kind)}
+      id={@id}
+      data-message={msg}
+      data-kind={@kind}
+      phx-hook="ShopifyToastHook"
+      hidden
+    >
+      <%= msg %>
+    </div>
+    """
+  end
 end

--- a/lib/shopify_app_web/components/shop_admin_components.ex
+++ b/lib/shopify_app_web/components/shop_admin_components.ex
@@ -1,0 +1,22 @@
+defmodule ShopifyAppWeb.ShopAdminComponents do
+  @moduledoc """
+  Components Specific to ShopAdmin
+  """
+  use Phoenix.Component
+  use ShopifyAppWeb, :verified_routes
+
+  @doc """
+  Basic Navigation links
+  """
+  def navigation_links(assigns) do
+    ~H"""
+    <div>
+      <ul>
+        <li><.link patch={~p"/shop_admin/shopify_app/"}>Home</.link></li>
+        <li><.link patch={~p"/shop_admin/shopify_app/settings"}>Settings</.link></li>
+        <li><.link patch={~p"/shop_admin/shopify_app/more"}>More Settings</.link></li>
+      </ul>
+    </div>
+    """
+  end
+end

--- a/lib/shopify_app_web/endpoint.ex
+++ b/lib/shopify_app_web/endpoint.ex
@@ -8,11 +8,15 @@ defmodule ShopifyAppWeb.Endpoint do
     store: :cookie,
     key: "_shopify_app_key",
     signing_salt: "ijq1g2Yt",
-    same_site: "None",
-    secure: true
+    same_site: "Lax"
   ]
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
+
+  # For the ShopAdmin, we do not need anything in the session outside of what we put there from the conn.
+  # by not defining session storage, we do not need to worry about cookies and how to access them.
+  # The session info will be populated AssignScope and store in the DOM on `data-phx-session`
+  socket "/shop_admin_live", Phoenix.LiveView.Socket, websocket: [connect_info: []]
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/lib/shopify_app_web/endpoint.ex
+++ b/lib/shopify_app_web/endpoint.ex
@@ -8,7 +8,8 @@ defmodule ShopifyAppWeb.Endpoint do
     store: :cookie,
     key: "_shopify_app_key",
     signing_salt: "ijq1g2Yt",
-    same_site: "Lax"
+    same_site: "None",
+    secure: true
   ]
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
@@ -44,10 +45,6 @@ defmodule ShopifyAppWeb.Endpoint do
     app_name: "shopify_app",
     prefix: "/shopify/webhook",
     callback: {ShopifyApp.WebhookHandler, :handle_webhook, []}
-
-  if Mix.env() == :dev do
-    plug ShopifyApp.Plug.DevProxy, upstream: "http://localhost:3000"
-  end
 
   plug ShopifyAdminProxy,
     upstream: "https://example.myshopify.com/admin/api/2022-04/graphql.json",

--- a/lib/shopify_app_web/live/shop_admin/assign_scope.ex
+++ b/lib/shopify_app_web/live/shop_admin/assign_scope.ex
@@ -1,0 +1,69 @@
+defmodule ShopifyAppWeb.ShopAdminLive.AssignScope do
+  @moduledoc """
+  Handles session authentication for ShopAdmin LiveViews.
+  This allows for patch navigation within a live_session.
+
+  This has a prerequisite of the user being authenticated through
+  the AuthShopSessionToken or AdminAuthenticator plug first
+  and we have the app and shop in the assigns.
+  We populate the session with the `app_name` and `myshopify_domain` from the assigns.
+  We can now populate the socket assigns from the session and the respective servers.
+
+  This is a good canditate for something that should be moved into ShopifyAPI.
+
+  # Example
+
+    live_session :my_session,
+      session: {ShopifyAppWeb.ShopAdminLive.AssignScope, :session, []}
+      on_mount: [ShopifyAppWeb.ShopAdminLive.AssignScope] do
+        ...
+    end
+  """
+  import Phoenix.Component
+
+  alias ShopifyAPI.AppServer
+  alias ShopifyAPI.AuthTokenServer
+  alias ShopifyAPI.ShopServer
+
+  require Logger
+
+  @doc """
+  Pull app and shop out of the assigns to store it in the session.
+
+  Session data is signed but not private so we are only storing the name and the domain.
+  """
+  def build_session(%{assigns: %{app: app, shop: shop}})
+      when is_struct(app, ShopifyAPI.App) and
+             is_struct(shop, ShopifyAPI.Shop),
+      do: %{"app_name" => app.name, "myshopify_domain" => shop.domain}
+
+  @doc """
+  Build the assigns from the app name and the shop domain put in the session with build_session.
+  """
+  def on_mount(:default, _params, session, socket) do
+    with {:ok, app} <- fetch_app(session["app_name"]),
+         {:ok, shop} <- fetch_shop(session["myshopify_domain"]),
+         {:ok, auth_token} <- AuthTokenServer.get(shop.domain, app.name) do
+      {:cont, assign(socket, :scope, %{app: app, shop: shop, auth_token: auth_token})}
+    else
+      {:error, error} ->
+        Logger.error("Invalid session info #{inspect(error)}")
+
+        {:halt, socket}
+    end
+  end
+
+  defp fetch_shop(myshopify_domain) do
+    case ShopServer.get(myshopify_domain) do
+      {:ok, shop} -> {:ok, shop}
+      :error -> {:error, :shop_not_found}
+    end
+  end
+
+  defp fetch_app(app_name) do
+    case AppServer.get(app_name) do
+      {:ok, app} -> {:ok, app}
+      :error -> {:error, :app_not_found}
+    end
+  end
+end

--- a/lib/shopify_app_web/live/shop_admin/index.ex
+++ b/lib/shopify_app_web/live/shop_admin/index.ex
@@ -17,6 +17,9 @@ defmodule ShopifyAppWeb.ShopAdminLive.Index do
 
   @impl true
   def handle_event("action", %{"title" => title}, socket) do
-    {:noreply, assign(socket, :page_title, "Home - " <> title)}
+    {:noreply,
+     socket
+     |> assign(:page_title, "Home - " <> title)
+     |> put_flash(:info, "A toast message from the flash!")}
   end
 end

--- a/lib/shopify_app_web/live/shop_admin/index.ex
+++ b/lib/shopify_app_web/live/shop_admin/index.ex
@@ -12,6 +12,11 @@ defmodule ShopifyAppWeb.ShopAdminLive.Index do
   end
 
   defp apply_action(socket, :live, _params) do
-    socket
+    assign(socket, :page_title, "Home")
+  end
+
+  @impl true
+  def handle_event("action", %{"title" => title}, socket) do
+    {:noreply, assign(socket, :page_title, "Home - " <> title)}
   end
 end

--- a/lib/shopify_app_web/live/shop_admin/index.ex
+++ b/lib/shopify_app_web/live/shop_admin/index.ex
@@ -1,0 +1,17 @@
+defmodule ShopifyAppWeb.ShopAdminLive.Index do
+  use ShopifyAppWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :live, _params) do
+    socket
+  end
+end

--- a/lib/shopify_app_web/live/shop_admin/index.ex
+++ b/lib/shopify_app_web/live/shop_admin/index.ex
@@ -1,5 +1,5 @@
 defmodule ShopifyAppWeb.ShopAdminLive.Index do
-  use ShopifyAppWeb, :live_view
+  use ShopifyAppWeb, :shop_admin_live_view
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/shopify_app_web/live/shop_admin/index.ex
+++ b/lib/shopify_app_web/live/shop_admin/index.ex
@@ -3,7 +3,7 @@ defmodule ShopifyAppWeb.ShopAdminLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    {:ok, assign(socket, :connected, connected?(socket))}
   end
 
   @impl true
@@ -13,6 +13,10 @@ defmodule ShopifyAppWeb.ShopAdminLive.Index do
 
   defp apply_action(socket, :live, _params) do
     assign(socket, :page_title, "Home")
+  end
+
+  defp apply_action(socket, other, _params) do
+    assign(socket, :page_title, "Home - #{other}")
   end
 
   @impl true

--- a/lib/shopify_app_web/live/shop_admin/index.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/index.html.heex
@@ -7,3 +7,5 @@
 <header>
   Example <strong>Home</strong> LiveView
 </header>
+
+<.navigation_links />

--- a/lib/shopify_app_web/live/shop_admin/index.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/index.html.heex
@@ -1,0 +1,9 @@
+<ui-title-bar title="Home">
+  <button variant="primary" onclick="console.log('Primary action')">
+    Primary action
+  </button>
+</ui-title-bar>
+
+<header>
+  Example <strong>Home</strong> LiveView
+</header>

--- a/lib/shopify_app_web/live/shop_admin/index.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/index.html.heex
@@ -1,7 +1,10 @@
-<ui-title-bar title="Home">
-  <button variant="primary" onclick="console.log('Primary action')">
+<ui-title-bar title={@page_title}>
+  <.button variant="primary" phx-click="action" phx-value-title="Primary">
     Primary action
-  </button>
+  </.button>
+  <.button phx-click="action" phx-value-title="Secondary">
+    Secondary action
+  </.button>
 </ui-title-bar>
 
 <header>

--- a/lib/shopify_app_web/live/shop_admin/index.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/index.html.heex
@@ -1,8 +1,8 @@
 <ui-title-bar title={@page_title}>
-  <.button variant="primary" phx-click="action" phx-value-title="Primary">
+  <.button variant="primary" data-phx-click="action" data-phx-value-title="Primary">
     Primary action
   </.button>
-  <.button phx-click="action" phx-value-title="Secondary">
+  <.button data-phx-click="action" data-phx-value-title="Secondary">
     Secondary action
   </.button>
 </ui-title-bar>

--- a/lib/shopify_app_web/live/shop_admin/index.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/index.html.heex
@@ -8,7 +8,8 @@
 </ui-title-bar>
 
 <header>
-  Example <strong>Home</strong> LiveView
+  Example <strong><%= @page_title %></strong> LiveView
 </header>
+Conected <%= @connected %>
 
 <.navigation_links />

--- a/lib/shopify_app_web/live/shop_admin/layouts.ex
+++ b/lib/shopify_app_web/live/shop_admin/layouts.ex
@@ -1,0 +1,5 @@
+defmodule ShopifyAppWeb.ShopAdminLive.Layouts do
+  use ShopifyAppWeb, :html
+
+  embed_templates "layouts/*"
+end

--- a/lib/shopify_app_web/live/shop_admin/layouts.ex
+++ b/lib/shopify_app_web/live/shop_admin/layouts.ex
@@ -1,5 +1,7 @@
 defmodule ShopifyAppWeb.ShopAdminLive.Layouts do
   use ShopifyAppWeb, :html
 
+  import ShopifyAppWeb.ShopAdminComponents
+
   embed_templates "layouts/*"
 end

--- a/lib/shopify_app_web/live/shop_admin/layouts/app.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/layouts/app.html.heex
@@ -1,0 +1,18 @@
+<main class="px-4 py-20 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-2xl">
+    <.flash kind={:info} title="Success!" flash={@flash} />
+    <.flash kind={:error} title="Error!" flash={@flash} />
+    <.flash
+      id="disconnected"
+      kind={:error}
+      title="We can't find the internet"
+      close={false}
+      autoshow={false}
+      phx-disconnected={show("#disconnected")}
+      phx-connected={hide("#disconnected")}
+    >
+      Attempting to reconnect <Heroicons.arrow_path class="ml-1 w-3 h-3 inline animate-spin" />
+    </.flash>
+    <%= @inner_content %>
+  </div>
+</main>

--- a/lib/shopify_app_web/live/shop_admin/layouts/app.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/layouts/app.html.heex
@@ -1,16 +1,5 @@
 <main class="px-4 py-20 sm:px-6 lg:px-8">
   <div class="mx-auto max-w-2xl">
-    <.flash
-      id="disconnected"
-      kind={:error}
-      title="We can't find the internet"
-      close={false}
-      autoshow={false}
-      phx-disconnected={show("#disconnected")}
-      phx-connected={hide("#disconnected")}
-    >
-      Attempting to reconnect <Heroicons.arrow_path class="ml-1 w-3 h-3 inline animate-spin" />
-    </.flash>
     <.toast kind={:info} flash={@flash} />
     <.toast kind={:error} flash={@flash} />
     <%= @inner_content %>

--- a/lib/shopify_app_web/live/shop_admin/layouts/app.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/layouts/app.html.heex
@@ -1,7 +1,5 @@
 <main class="px-4 py-20 sm:px-6 lg:px-8">
   <div class="mx-auto max-w-2xl">
-    <.flash kind={:info} title="Success!" flash={@flash} />
-    <.flash kind={:error} title="Error!" flash={@flash} />
     <.flash
       id="disconnected"
       kind={:error}
@@ -13,6 +11,8 @@
     >
       Attempting to reconnect <Heroicons.arrow_path class="ml-1 w-3 h-3 inline animate-spin" />
     </.flash>
+    <.toast kind={:info} flash={@flash} />
+    <.toast kind={:error} flash={@flash} />
     <%= @inner_content %>
   </div>
 </main>

--- a/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
@@ -19,6 +19,8 @@
     <ui-nav-menu>
       <a href="/shop_admin/shopify_app/" rel="home">Root</a>
       <a href="/shop_admin/shopify_app/">Home</a>
+      <a href="/shop_admin/shopify_app/settings">Settings</a>
+      <a href="/shop_admin/shopify_app/more">More Settings</a>
     </ui-nav-menu>
   </head>
   <body class="bg-white antialiased">

--- a/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
@@ -13,7 +13,7 @@
     </script>
 
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
-    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/shop_admin.js"}>
     </script>
 
     <ui-nav-menu>

--- a/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
@@ -12,8 +12,8 @@
     <script src="https://cdn.shopify.com/shopifycloud/app-bridge.js">
     </script>
 
-    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
-    <script defer phx-track-static type="text/javascript" src={~p"/assets/shop_admin.js"}>
+    <link data-phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <script defer data-phx-track-static type="text/javascript" src={~p"/assets/shop_admin.js"}>
     </script>
 
     <ui-nav-menu>

--- a/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
@@ -17,10 +17,11 @@
     </script>
 
     <ui-nav-menu>
-      <a href="/shop_admin/shopify_app/" rel="home">Root</a>
-      <a href="/shop_admin/shopify_app/">Home</a>
-      <a href="/shop_admin/shopify_app/settings">Settings</a>
-      <a href="/shop_admin/shopify_app/more">More Settings</a>
+      <a href="/live_shop_admin/" rel="home">Root</a>
+      <a href="/live_shop_admin/">Home</a>
+      <a href="/live_shop_admin/show">Show</a>
+      <a href="/live_shop_admin/settings">Settings</a>
+      <a href="/live_shop_admin/more">More Settings</a>
     </ui-nav-menu>
   </head>
   <body class="bg-white antialiased">

--- a/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/layouts/root.html.heex
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en" style="scrollbar-gutter: stable;">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="csrf-token" content={get_csrf_token()} />
+    <meta name="shopify-api-key" content={ShopifyApp.Config.api_key()} />
+
+    <%!-- Polaris CSS --%>
+    <link rel="stylesheet" href="https://unpkg.com/@shopify/polaris@11.14.0/build/esm/styles.css" />
+    <%!-- AppBridge JS --%>
+    <script src="https://cdn.shopify.com/shopifycloud/app-bridge.js">
+    </script>
+
+    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
+    </script>
+
+    <ui-nav-menu>
+      <a href="/shop_admin/shopify_app/" rel="home">Root</a>
+      <a href="/shop_admin/shopify_app/">Home</a>
+    </ui-nav-menu>
+  </head>
+  <body class="bg-white antialiased">
+    <%= @inner_content %>
+  </body>
+</html>

--- a/lib/shopify_app_web/live/shop_admin/settings.ex
+++ b/lib/shopify_app_web/live/shop_admin/settings.ex
@@ -3,7 +3,7 @@ defmodule ShopifyAppWeb.ShopAdminLive.Settings do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    {:ok, assign(socket, :connected, connected?(socket))}
   end
 
   @impl true
@@ -17,5 +17,13 @@ defmodule ShopifyAppWeb.ShopAdminLive.Settings do
 
   defp apply_action(socket, :more_settings, _params) do
     assign(socket, :page_title, "More Settings")
+  end
+
+  @impl true
+  def handle_event("action", %{"title" => title}, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, "Settings - " <> title)
+     |> put_flash(:info, "A toast message from the flash!")}
   end
 end

--- a/lib/shopify_app_web/live/shop_admin/settings.ex
+++ b/lib/shopify_app_web/live/shop_admin/settings.ex
@@ -1,0 +1,22 @@
+defmodule ShopifyAppWeb.ShopAdminLive.Settings do
+  use ShopifyAppWeb, :shop_admin_live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    connected?(socket) |> dbg
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :settings, _params) do
+    assign(socket, :page_title, "Settings")
+  end
+
+  defp apply_action(socket, :more_settings, _params) do
+    assign(socket, :page_title, "More Settings")
+  end
+end

--- a/lib/shopify_app_web/live/shop_admin/settings.ex
+++ b/lib/shopify_app_web/live/shop_admin/settings.ex
@@ -3,7 +3,6 @@ defmodule ShopifyAppWeb.ShopAdminLive.Settings do
 
   @impl true
   def mount(_params, _session, socket) do
-    connected?(socket) |> dbg
     {:ok, socket}
   end
 

--- a/lib/shopify_app_web/live/shop_admin/settings.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/settings.html.heex
@@ -1,0 +1,9 @@
+<ui-title-bar title={@page_title}>
+  <button onclick="console.log('Secondary action')">Secondary action</button>
+</ui-title-bar>
+
+<header>
+  Example <strong>Settings</strong> LiveView
+</header>
+
+<.navigation_links />

--- a/lib/shopify_app_web/live/shop_admin/settings.html.heex
+++ b/lib/shopify_app_web/live/shop_admin/settings.html.heex
@@ -1,9 +1,12 @@
 <ui-title-bar title={@page_title}>
-  <button onclick="console.log('Secondary action')">Secondary action</button>
+  <.button data-phx-click="action" data-phx-value-title="Secondary">
+    Secondary action
+  </.button>
 </ui-title-bar>
 
 <header>
-  Example <strong>Settings</strong> LiveView
+  Example <strong><%= @page_title %></strong> LiveView
 </header>
+Conected <%= @connected %> <%= @live_action %> <%= @scope.shop.domain %>
 
 <.navigation_links />

--- a/lib/shopify_app_web/router.ex
+++ b/lib/shopify_app_web/router.ex
@@ -42,12 +42,15 @@ defmodule ShopifyAppWeb.Router do
     end
   end
 
-  scope "/shop_admin/:app", ShopifyAppWeb do
-    pipe_through :browser
-    pipe_through :shop_admin
+  live_session :shop_admin,
+    layout: {ShopifyAppWeb.ShopAdminLive.Layouts, :app},
+    root_layout: {ShopifyAppWeb.ShopAdminLive.Layouts, :root} do
+    scope "/shop_admin/:app", ShopifyAppWeb do
+      pipe_through :browser
+      pipe_through :shop_admin
 
-    get "/", ShopAdminController, :index
-    get "/*path", ShopAdminController, :index
+      live "/", ShopAdminLive.Index, :live
+    end
   end
 
   # Other scopes may use custom stacks.

--- a/lib/shopify_app_web/router.ex
+++ b/lib/shopify_app_web/router.ex
@@ -15,7 +15,7 @@ defmodule ShopifyAppWeb.Router do
   end
 
   pipeline :shop_admin do
-    plug ShopifyAPI.Plugs.AdminAuthenticator, shopify_router_mount: "/shop"
+    plug ShopifyAPI.Plugs.AdminAuthenticator, app_name: "shopify_app"
     plug ShopifyAPI.Plugs.PutShopifyContentHeaders
   end
 
@@ -42,14 +42,17 @@ defmodule ShopifyAppWeb.Router do
     end
   end
 
-  live_session :shop_admin,
+  live_session :live_shop_admin,
     layout: {ShopifyAppWeb.ShopAdminLive.Layouts, :app},
-    root_layout: {ShopifyAppWeb.ShopAdminLive.Layouts, :root} do
-    scope "/shop_admin/:app", ShopifyAppWeb do
+    root_layout: {ShopifyAppWeb.ShopAdminLive.Layouts, :root},
+    on_mount: [ShopifyAppWeb.ShopAdminLive.AssignScope],
+    session: {ShopifyAppWeb.ShopAdminLive.AssignScope, :build_session, []} do
+    scope "/live_shop_admin", ShopifyAppWeb do
       pipe_through :browser
       pipe_through :shop_admin
 
       live "/", ShopAdminLive.Index, :live
+      live "/show", ShopAdminLive.Index, :show
       live "/settings", ShopAdminLive.Settings, :settings
       live "/more", ShopAdminLive.Settings, :more_settings
     end

--- a/lib/shopify_app_web/router.ex
+++ b/lib/shopify_app_web/router.ex
@@ -50,6 +50,8 @@ defmodule ShopifyAppWeb.Router do
       pipe_through :shop_admin
 
       live "/", ShopAdminLive.Index, :live
+      live "/settings", ShopAdminLive.Settings, :settings
+      live "/more", ShopAdminLive.Settings, :more_settings
     end
   end
 

--- a/test/shopify_app_web/live/shop_admin/index_test.exs
+++ b/test/shopify_app_web/live/shop_admin/index_test.exs
@@ -5,13 +5,14 @@ defmodule ShopifyAppWeb.ShopAdminLive.IndexTest do
   import ShopifyApp.ShopTestSetup
 
   describe "ShopAdminLive.Index render" do
-    setup [:shop]
+    setup [:app_auth_token_shop]
 
-    test "disconnected and connected mount", %{conn: conn, shopifyapi_shop: shop} do
+    test "disconnected and connected mount", %{conn: conn, shopifyapi_shop: shop, app: app} do
       conn =
         conn
         |> assign(:shop, shop)
-        |> get("/shop_admin/shopify_shop")
+        |> assign(:app, app)
+        |> get("/live_shop_admin")
 
       assert html_response(conn, 200) =~ "Example <strong>Home</strong> LiveView"
 

--- a/test/shopify_app_web/live/shop_admin/index_test.exs
+++ b/test/shopify_app_web/live/shop_admin/index_test.exs
@@ -1,0 +1,21 @@
+defmodule ShopifyAppWeb.ShopAdminLive.IndexTest do
+  use ShopifyAppWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import ShopifyApp.ShopTestSetup
+
+  describe "ShopAdminLive.Index render" do
+    setup [:shop]
+
+    test "disconnected and connected mount", %{conn: conn, shopifyapi_shop: shop} do
+      conn =
+        conn
+        |> assign(:shop, shop)
+        |> get("/shop_admin/shopify_shop")
+
+      assert html_response(conn, 200) =~ "Example <strong>Home</strong> LiveView"
+
+      {:ok, _view, _html} = live(conn)
+    end
+  end
+end

--- a/test/support/shop_test_setup.ex
+++ b/test/support/shop_test_setup.ex
@@ -2,7 +2,9 @@ defmodule ShopifyApp.ShopTestSetup do
   import ShopifyApp.Factory
 
   def app_auth_token_shop(context) do
-    [shop: shop, shopifyapi_shop: _] = shop(context)
+    shop_context = shop(context)
+    shop = Keyword.fetch!(shop_context, :shop)
+    shopifyapi_shop = Keyword.fetch!(shop_context, :shopifyapi_shop)
     [app: app] = app(context)
     [token: token] = auth_token(%{shop: shop})
     [shop_admin_token: shop_admin_token] = shop_admin_token(%{shop: shop, app: app})
@@ -11,6 +13,7 @@ defmodule ShopifyApp.ShopTestSetup do
       app: app,
       auth_token: token,
       shop: shop,
+      shopifyapi_shop: shopifyapi_shop,
       shop_admin_token: shop_admin_token
     ]
   end


### PR DESCRIPTION
Adds the most barebones shop admin liveview. Just enough to show that it renders inside of Shopify admin.

![image](https://github.com/orbit-apps/elixir-shopify-app/assets/16840642/2e39be6f-4e70-4a77-bbcb-511bab2a6e53)


https://github.com/orbit-apps/elixir-shopify-app/assets/16840642/c0d2cbb9-4201-438c-b848-3f2229c03e6f

